### PR TITLE
Reconfigured CICD .yaml to Separate Jobs and Run JSDoc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,33 +11,21 @@ on:
       - dev
 
 jobs:
-  jest:
+  main:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-
+      
       - name: Run Tests
         run: |
           npm ci 
           npm test
-      
-      - name: Run Lint Check
-        run: npm run lint
-
-  build:
-    runs-on: ubuntu-latest
-    needs: [jest]
-    steps:
-      - uses: actions/checkout@v1
 
       - name: Run Build
         run: npm run build
-
-  jsdoc:
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - uses: actions/checkout@v1
+          
+      - name: Run Lint Check
+        run: npm run lint
 
       - name: Run JSDoc
         run: npm run doc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,15 +18,6 @@ jobs:
       - name: Install Dependencies
         run: npm ci 
 
-  build:
-    runs-on: ubuntu-latest
-    needs: [dependencies]
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: Run Build
-        run: npm run build
-
   jest:
     runs-on: ubuntu-latest
     needs: [build]
@@ -38,6 +29,15 @@ jobs:
       
       - name: Run Lint Check
         run: npm run lint
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [dependencies]
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Run Build
+        run: npm run build
 
   jsdoc:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,17 +11,39 @@ on:
       - dev
 
 jobs:
-  Jest:
+  dependencies:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Run Tests
-        run: |
-          npm ci 
-          npm test
+      - name: Install Dependencies
+        run: npm ci 
 
-      - name: Build
+  build:
+    runs-on: ubuntu-latest
+    needs: [dependencies]
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Run Build
         run: npm run build
-          
-      - name: Lint
+
+  jest:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Run Tests
+        run: npm test
+      
+      - name: Run Lint Check
         run: npm run lint
+
+  jsdoc:
+    runs-on: ubuntu-latest
+    needs: [jest]
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Run JSDoc
+        run: npm run doc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
   jest:
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [dependencies]
     steps:
       - uses: actions/checkout@v1
 
@@ -32,7 +32,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [dependencies]
+    needs: [jest]
     steps:
       - uses: actions/checkout@v1
 
@@ -41,7 +41,7 @@ jobs:
 
   jsdoc:
     runs-on: ubuntu-latest
-    needs: [jest]
+    needs: [build]
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,13 +11,6 @@ on:
       - dev
 
 jobs:
-  dependencies:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install Dependencies
-        run: npm ci 
-
   jest:
     runs-on: ubuntu-latest
     needs: [dependencies]
@@ -25,7 +18,9 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Run Tests
-        run: npm test
+        run: |
+          npm ci 
+          npm test
       
       - name: Run Lint Check
         run: npm run lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   jest:
     runs-on: ubuntu-latest
-    needs: [dependencies]
     steps:
       - uses: actions/checkout@v1
 


### PR DESCRIPTION
### Description

Current .yaml file for CICD setup contained all steps under one job and didn't build the JSDoc automatically.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation

### Self - Checklist

- [x] Code has been commented appropriately
- [x] Code has been lint checked locally
- [x] I have assigned a reviewer to my PR